### PR TITLE
refactor for diagonal move

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,23 +1,20 @@
 class Pawn < Piece
-  
   def legal_move?(x, y)
+    return false if backwards_move?(y)
 
-    x_diff = (x_position - x).abs
-
-    if x_diff.zero?  
-      return false if backwards_move?(y)
-      proper_length?(y)
-    elsif x_diff == 1
-      #  check for capture move
-      return false
-      # end
-    else  # otherwise has illegal horizontal component
-      return false
+    unless capture_move?(x, y)
+      return false if horizontal_move?(x)
     end
-    
+
+    proper_length?(y)
   end
 
   private
+
+  def horizontal_move?(x)
+    x_diff = (x_position - x).abs
+    x_diff != 0
+  end
 
   def backwards_move?(y)
     color ? y_position > y : y_position < y   
@@ -30,6 +27,20 @@ class Pawn < Piece
   def proper_length?(y)
     y_diff = (y - y_position).abs
     first_move?(y) ? (y_diff == 1 || y_diff == 2) : y_diff == 1
+  end
+
+  def capture_move?(x, y)
+    x_diff = (x_position - x).abs
+    y_diff = (y_position - y).abs
+
+    # unless game.obstruction?(x, y)
+    # return false
+    # end
+
+    # diagonal move of one
+    # (x_diff == 1) && (y_diff == 1)
+
+    return false 
   end
 
 end

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -18,6 +18,11 @@ class PawnTest < ActiveSupport::TestCase
     assert_equal false, pawn.legal_move?(1, 4)
   end
 
+  test "illegal white diagonal move" do
+    pawn = FactoryGirl.create(:pawn, x_position: 1, y_position: 1, color: true)
+    assert_equal false, pawn.legal_move?(2, 2)
+  end
+
   # Legal White Moves
   test "legal white first move" do
     pawn = FactoryGirl.create(:pawn, x_position: 1, y_position: 1, color: true)
@@ -43,6 +48,11 @@ class PawnTest < ActiveSupport::TestCase
   test "illegal black first move" do
     pawn = FactoryGirl.create(:pawn, x_position: 1, y_position: 6, color: false)
     assert_equal false, pawn.legal_move?(1, 3)
+  end
+
+  test "illegal black diagonal move" do
+    pawn = FactoryGirl.create(:pawn, x_position: 1, y_position: 5, color: false)
+    assert_equal false, pawn.legal_move?(0, 4)
   end
 
   # Legal Black Moves


### PR DESCRIPTION
Refactor pawn legal_move? logic so that it is human-readable and concise. Also, create a placeholder for capture_move? 