### PR TITLE
Update game controller

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -26,7 +26,7 @@ class GamesController < ApplicationController
 			randomize_players  # if unique redirect to games path otherwise an error.
 			redirect_to game_path(@game)
 		else
-			render :text, :status => :unprocessable_entity
+			render :new, :status => :unprocessable_entity
 		end
 	end
 

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -24,7 +24,7 @@ class GamesControllerTest < ActionController::TestCase
     game = FactoryGirl.create(:game, white_player_id: 3)
     put :update, :id => game.id, :game => { :black_player_id => 3 }
     game.reload
-    assert_redirected_to game_path(game)
+    assert_response :unprocessable_entity, "Should respond unprocessable_entity"
     assert_nil game.black_player_id, "black_player_id should be nil"
   end
 


### PR DESCRIPTION
This updates game controller to respond :unprocessable_entity on identical players (which should never be called under normal game flow because the join game button is not rendered).

Test is updated to fail if user is not signed in.