### PR TITLE
Refactor valid move and pass tests

### DIFF
--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -4,19 +4,7 @@ class Bishop < Piece
   end
 
   def obstructed_move?(x,y)
-  	
-    return true if obstructed_diagonally?(x, y)
-    
-    # capture logic  - I think this can get refactored into a method used by all the pieces except pawn
-    destination_obstruction = game.obstruction(x, y) # is there something at the destination?
-    if destination_obstruction && destination_obstruction.color == self.color
-      # yes and it's the same color - it's an obstruction
-      return true
-    elsif destination_obstruction && destination_obstruction.color != self.color
-      # yes but it's a different color - capture it
-      # destination_obstruction.mark_captured
-      return false # no obstruction, piece should move there.
-    end
+  	return true if obstructed_diagonally?(x, y)
     
     return false
   end

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -4,8 +4,6 @@ class Bishop < Piece
   end
 
   def obstructed_move?(x,y)
-  	return true if obstructed_diagonally?(x, y)
-    
-    return false
+  	obstructed_diagonally?(x, y)
   end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -5,7 +5,7 @@ class King < Piece
 
   def obstructed_move?(x, y)
     # king moves one space - can't be obstructed
-    return false
+    false
   end
 end
 

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -4,6 +4,7 @@ class King < Piece
   end
 
   def obstructed_move?(x, y)
+    # king moves one space - can't be obstructed
     return false
   end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -2,6 +2,10 @@ class King < Piece
 	def legal_move?(x, y)
     proper_length?(x, y)
   end
+
+  def obstructed_move?(x, y)
+    return false
+  end
 end
 
 private

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -6,12 +6,7 @@ class Knight < Piece
   end
 
   def obstructed_move?(x, y)
-    
-    destination_obstruction = game.obstruction(x, y)
-    if destination_obstruction && destination_obstruction.color == self.color
-      # yes and it's the same color - it's an obstruction
-      return true
-    end
+    # knight jumps over pieces - can't be obstructed
     return false 
   end
 

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -11,10 +11,7 @@ class Knight < Piece
     if destination_obstruction && destination_obstruction.color == self.color
       # yes and it's the same color - it's an obstruction
       return true
-
-      # can include else and capture logic here
     end
-
     return false 
   end
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -9,6 +9,10 @@ class Pawn < Piece
     proper_length?(y)
   end
 
+  def obstructed_move?(x, y)
+    return false
+  end
+
   private
 
   def horizontal_move?(x)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -10,6 +10,7 @@ class Pawn < Piece
   end
 
   def obstructed_move?(x, y)
+    # pawn could be obstructed on a 2 square move!
     return false
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -91,6 +91,8 @@ class Piece < ActiveRecord::Base
         pos_y += 1
       end
     end
+    
+    return false
   end
 
   def obstructed_move?(x, y)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -23,6 +23,9 @@ class Piece < ActiveRecord::Base
     # check that destination isn't blocked by piece of same color
     return false if destination_obstructed?(x, y)
 
+    # check that the move doesn't put the king into check
+    # return false if move_causes_check?(x, y)
+
     # otherwise return true
     return true
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -128,6 +128,8 @@ class Piece < ActiveRecord::Base
         end
       end
     end
+
+    return false
   end
 
   private

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -8,29 +8,53 @@ class Piece < ActiveRecord::Base
   belongs_to :game
 
   def valid_move?(x, y)
-    move_on_board?(x, y) && legal_move?(x, y)
-  end
+    #check to make sure move isn't back to same spot
+    return false if nil_move?(x, y)
 
-  def move_on_board?(x, y)
-    (x <= MAX_BOARD_SIZE && x >= MIN_BOARD_SIZE) && (y <= MAX_BOARD_SIZE && y >= MIN_BOARD_SIZE)
-  end
+    # check if move is on board
+    return false if !move_on_board?(x, y)
 
-  def legal_move?(x, y)
-    raise NotImplementedError "Pieces must implement #legal_move?"
-  end
+    # check that move is legal, implemented by each piece
+    return false if !legal_move?(x, y)
 
-  def obstructed_move?(x, y)
-    raise NotImplementedError "Pieces must implement #obstructed_move?"
+    # check that move is not obstructed
+    return false if obstructed_move?(x, y)
+    
+    # check that destination isn't blocked by piece of same color
+    return false if destination_obstructed?(x, y)
+
+    # otherwise return true
+    return true
   end
 
   def color_name
     color ? "white" : "black"
   end
 
+  def destination_obstructed?(x, y)
+    destination_obstruction = game.obstruction(x, y) # is there something at the destination?
+    if destination_obstruction && destination_obstruction.color == self.color
+      # yes and it's the same color - it's an destination_obstruction
+      return true
+    end
+  end
+
+  def legal_move?(x, y)
+    raise NotImplementedError "Pieces must implement #legal_move?"
+  end
+
   def mark_captured
     self.update_attributes( captured?: true, x_position: nil, y_position: nil)
   end
   
+  def move_on_board?(x, y)
+    (x <= MAX_BOARD_SIZE && x >= MIN_BOARD_SIZE) && (y <= MAX_BOARD_SIZE && y >= MIN_BOARD_SIZE)
+  end
+  
+  def nil_move?(x, y)
+    x_position == x && y_position == y
+  end
+
   def obstructed_diagonally?(x, y)
     pos_x = x_position
     pos_y = y_position
@@ -64,6 +88,10 @@ class Piece < ActiveRecord::Base
         pos_y += 1
       end
     end
+  end
+
+  def obstructed_move?(x, y)
+    raise NotImplementedError "Pieces must implement #obstructed_move?"
   end
 
   def obstructed_rectilinearly?(x, y)

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -5,9 +5,6 @@ class Queen < Piece
   end
 
   def obstructed_move?(x, y)
-    return true if obstructed_diagonally?(x, y)
-    return true if obstructed_rectilinearly?(x, y)
-
-    return false 
+    obstructed_diagonally?(x, y) || obstructed_rectilinearly?(x, y)
   end
 end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -5,21 +5,9 @@ class Queen < Piece
   end
 
   def obstructed_move?(x, y)
-    
     return true if obstructed_diagonally?(x, y)
     return true if obstructed_rectilinearly?(x, y)
-    
-    # capture logic  - I think this can get refactored into a method used by all the pieces except pawn
-    destination_obstruction = game.obstruction(x, y) # is there something at the destination?
-    if destination_obstruction && destination_obstruction.color == self.color
-      # yes and it's the same color - it's an obstruction
-      return true
-    elsif destination_obstruction && destination_obstruction.color != self.color
-      # yes but it's a different color - capture it
-      # destination_obstruction.mark_captured
-      return false # no obstruction, piece should move there.
-    end
-    
+
     return false 
   end
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -16,20 +16,7 @@ class Rook < Piece
 
   def obstructed_move?(x, y)
     
-    return true if obstructed_rectilinearly?(x, y)
+    obstructed_rectilinearly?(x, y)
     
-    # capture logic  - I think this can get refactored into a method used by all the pieces except pawn
-    destination_obstruction = game.obstruction(x, y) # is there something at the destination?
-    if destination_obstruction && destination_obstruction.color == self.color
-      # yes and it's the same color - it's an obstruction
-      return true
-    elsif destination_obstruction && destination_obstruction.color != self.color
-      # yes but it's a different color - capture it
-      # destination_obstruction.mark_captured
-      return false # no obstruction, piece should move there.
-    end
-
-    return false 
-
   end
 end

--- a/test/models/king_test.rb
+++ b/test/models/king_test.rb
@@ -1,21 +1,21 @@
 require 'test_helper'
 
-class PawnTest < ActiveSupport::TestCase
+class KingTest < ActiveSupport::TestCase
 
   test "legal moves" do
     game = FactoryGirl.create(:game)
     king = FactoryGirl.create(:king, x_position: 4, y_position: 0)
 
-    assert king.valid_move?(4, 1)
-    assert king.valid_move?(5, 1)
+    assert king.legal_move?(4, 1)
+    assert king.legal_move?(5, 1)
   end
 
   test "illegal moves" do
     game = FactoryGirl.create(:game)
     king = FactoryGirl.create(:king, x_position: 4, y_position: 0)
 
-    assert_not king.valid_move?(6, 0)
-    assert_not king.valid_move?(4, -1)
+    assert_not king.legal_move?(6, 0)
+    assert_not king.legal_move?(4, 3)
   end
 
 end

--- a/test/models/knight_test.rb
+++ b/test/models/knight_test.rb
@@ -1,20 +1,20 @@
 require 'test_helper'
 
-class PawnTest < ActiveSupport::TestCase
+class KnightTest < ActiveSupport::TestCase
 
-  test "valid knight moves" do
+  test "legal knight moves" do
     setup_knight
 
-    assert @knight.valid_move?(5, 6)
-    assert @knight.valid_move?(2, 3)
+    assert @knight.legal_move?(5, 6)
+    assert @knight.legal_move?(2, 3)
   end
  
-  test "invalid knight moves" do
+  test "illegal knight moves" do
     setup_knight
 
-    assert_not @knight.valid_move?(5, 5), "diagonal knight move"
-    assert_not @knight.valid_move?(4, 6), "vertical knight move"
-    assert_not @knight.valid_move?(5, 4), "horizontal knight move"
+    assert_not @knight.legal_move?(5, 5), "diagonal knight move"
+    assert_not @knight.legal_move?(4, 6), "vertical knight move"
+    assert_not @knight.legal_move?(5, 4), "horizontal knight move"
 
   end
 

--- a/test/models/knight_test.rb
+++ b/test/models/knight_test.rb
@@ -18,13 +18,6 @@ class KnightTest < ActiveSupport::TestCase
 
   end
 
-  test "obstructed knight moves" do
-    setup_knight
-
-    assert @knight.obstructed_move?(5, 6)
-    assert @white_knight.obstructed_move?(5, 1)
-  end
-
   test "unobstructed knight moves" do
     setup_knight
 

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -39,4 +39,22 @@ class PieceTest < ActiveSupport::TestCase
 
   end
 
+  test "Should recognize nil move" do 
+    piece = FactoryGirl.create(:rook, x_position: 5, y_position: 4)
+
+    assert piece.nil_move?(5, 4)
+    assert_not piece.nil_move?(5, 5)
+  end
+
+  test "Should recognize destination_obstructed move" do 
+    game = FactoryGirl.create(:game)
+    piece = FactoryGirl.create(:rook, x_position: 5, y_position: 4, color: true, game_id: game.id)
+
+
+    assert piece.destination_obstructed?(5, 1), "White rook obstructed by white pawn"
+    assert_not piece.destination_obstructed?(5, 6), "White rook not obstructed by black pawn"
+    assert_not piece.destination_obstructed?(5, 9), "Not obstructed at empty space"
+  end
+
+
 end

--- a/test/models/queen_test.rb
+++ b/test/models/queen_test.rb
@@ -2,18 +2,20 @@ require 'test_helper'
 
 class QueenTest < ActiveSupport::TestCase
   
-  test "queen valid moves" do
-    queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
+  test "queen legal moves" do
+    game = FactoryGirl.create(:game)
+    queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4, game_id: game.id)
 
-    assert queen.valid_move?(6, 6)
-    assert queen.valid_move?(4, 0)
-    assert queen.valid_move?(3, 4)
+    assert queen.legal_move?(6, 6)
+    assert queen.legal_move?(4, 0)
+    assert queen.legal_move?(3, 4)
   end
 
-  test "queen invalid moves" do
-    queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
+  test "queen illegal moves" do
+    game = FactoryGirl.create(:game)
+    queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4, game_id: game.id)
 
-    assert_not queen.valid_move?(5, 6)
+    assert_not queen.legal_move?(5, 6)
   end
 
   test "queen move obstructed" do 
@@ -22,10 +24,10 @@ class QueenTest < ActiveSupport::TestCase
     @game.pieces.create( type: 'Pawn', x_position: 6, y_position: 4, color: true )
     @game.pieces.create( type: 'Pawn', x_position: 2, y_position: 4, color: true )
 
-    assert @queen.obstructed_move?(4,7), "queen is blocked up"
-    assert @queen.obstructed_move?(4,1), "queen is blocked down"
-    assert @queen.obstructed_move?(7,4), "queen is blocked to right"
-    assert @queen.obstructed_move?(1,4), "queen is blocked to left"
+    assert @queen.obstructed_move?(4, 7), "queen is blocked up"
+    assert @queen.obstructed_move?(4, 0), "queen is blocked down"
+    assert @queen.obstructed_move?(7, 4), "queen is blocked to right"
+    assert @queen.obstructed_move?(1, 4), "queen is blocked to left"
     assert @queen.obstructed_move?(7, 7), "quad 1"
     assert @queen.obstructed_move?(7, 1), "quad 2"
     assert @queen.obstructed_move?(1, 1), "quad 3"

--- a/test/models/rook_test.rb
+++ b/test/models/rook_test.rb
@@ -23,7 +23,7 @@ class RookTest < ActiveSupport::TestCase
 
   test "obstructed moves" do
     setup_obstruction_tests
-    assert @rook.obstructed_move?(4,6), "Rook is blocked up"
+    assert @rook.obstructed_move?(4,7), "Rook is blocked up"
     assert @rook.obstructed_move?(4,0), "Rook is blocked down"
     assert @rook2.obstructed_move?(4,0), "Rook is blocked to right"
     assert @rook3.obstructed_move?(4,7), "Rook is blocked to left"


### PR DESCRIPTION
@johnellison @hsinkoff @MCHLWRRN 

Refactored valid_move? as discussed in the Trello slide @hsinkoff made. - please provide feedback
Implemented two new piece methods, nil_move?(x, y) and destination_obstructed?(x, y)
Alphabetized piece.rb methods
Tweaked many of the existing piece tests for a number of reasons -
1. test was titled check legal move but was calling valid_move?
2. test was titled check obstructed move but looked at destination
3. added game_id to some tests which required piece look up (destination_obstructed called)

Additional testing should be considered before merging.

I added a PR because I couldn't find a way to comment on an entire branch, but this PR isn't ready for prime time