### PR TITLE
update check? query to eager load

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -11,7 +11,7 @@ class Game < ActiveRecord::Base
 
   def check?(color)
     king = pieces.find_by(type: 'King', color: color)
-    opponents = pieces.where(
+    opponents = pieces.includes(:game).where(
       "color = ? and state != 'captured'",
       !color).to_a
 


### PR DESCRIPTION
OK, this is only one line of code, so doesn't really show that I spent half the afternoon figuring it out.  I finally narrowed the 16 db queries to the check? method and realized that they were being caused by the moving_own_piece? method, in particular the game.turn. Each piece had to be checked for valid_move and all of the piece attributes were loaded but game.turn required a db query. In the end this one line change brings all the game info into persisted memory in one db query and eliminates 16 queries, which will be huge when we start running check_mate? methods.  @kenmazaika I saved you the energy of sending me a rubber duck as I had written a paragraph in slack and was about to hit send when I had the epiphany.  Time for a Friday night beer.