### PR TITLE
remove margin-bottom on flashes

### DIFF
--- a/app/assets/stylesheets/_flashes.scss
+++ b/app/assets/stylesheets/_flashes.scss
@@ -10,7 +10,7 @@ $success-color: #e6efc2 !default;
   display: block;
   font-family: $sans-serif-font;
   font-weight: 700;
-  margin-bottom: $base-spacing / 2;
+  margin-bottom: 0;
   padding: $base-spacing / 2;
   text-align: center;
   text-transform: uppercase;


### PR DESCRIPTION
Tiny fix: remove margin-bottom on flashes so there's no whitespace when user logs in and is given confirmation on homepage.