### PR TITLE
Move moving_own_piece out of valid_move

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -12,7 +12,7 @@ class Piece < ActiveRecord::Base
 
   def attempt_move(piece, params)
     Piece.transaction do
-      move_to(piece, params)
+      move_to(piece, params) if moving_own_piece?
       game = piece.game
       game.update_attributes(state: nil)
       if game.check?(color)
@@ -47,7 +47,7 @@ class Piece < ActiveRecord::Base
     x = params[:x_position].to_i
     y = params[:y_position].to_i
 
-    if piece.valid_move?(x, y) && moving_own_piece?
+    if piece.valid_move?(x, y)
       if capture_move?(x, y)
         captured = game.obstruction(x, y)
         captured.update_piece(nil, nil, 'captured')

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -47,7 +47,7 @@ class Piece < ActiveRecord::Base
     x = params[:x_position].to_i
     y = params[:y_position].to_i
 
-    if piece.valid_move?(x, y)
+    if piece.valid_move?(x, y) && moving_own_piece?
       if capture_move?(x, y)
         captured = game.obstruction(x, y)
         captured.update_piece(nil, nil, 'captured')
@@ -74,7 +74,6 @@ class Piece < ActiveRecord::Base
   def valid_move?(x, y)
     return false if nil_move?(x, y)
     return false unless move_on_board?(x, y)
-    return false unless moving_own_piece?
     return false unless legal_move?(x, y)
     return false if obstructed_move?(x, y)
     return false if destination_obstructed?(x, y)


### PR DESCRIPTION
Remove moving_own_piece from valid_move? to assist with check? and checkmate? methods.
Add moving_own_piece check to attempt_move to ensure that it is still check on an actual move.
