### PR TITLE
Refactor obstructions

### DIFF
--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -6,12 +6,4 @@ class Bishop < Piece
   def obstructed_squares(x, y)
     diagonal_obstruction_array(x, y)
   end
-
-  def x_scope
-    7
-  end
-
-  def y_scope
-    7
-  end
 end

--- a/app/models/concerns/obstructions.rb
+++ b/app/models/concerns/obstructions.rb
@@ -1,10 +1,13 @@
 module Obstructions
+  # determines if a particular x, y coordinate is already occupied by a piece of the same color
   def destination_obstructed?(x, y)
     destination_obstruction = game.obstruction(x, y) # is there something at the destination
     # if it's the same color as piece it's a destination_obstruction
     destination_obstruction && destination_obstruction.color == color
   end
 
+  # create an array of location tuples [x,y] to be checked later for obstruction
+  # this method checks diagonally for queen and bishop
   def diagonal_obstruction_array(x, y)
     # store piece x & y positions in local variables
     pos_x = x_position
@@ -36,6 +39,8 @@ module Obstructions
     obstruction_array
   end
 
+  # create an array of location tuples [x,y] to be checked later for obstruction
+  # this method checks rectilinearly for queen, rook and king on castling moves
   def rectilinear_obstruction_array(x, y)
     # store piece x & y positions in local variables
     pos_x = x_position
@@ -53,7 +58,6 @@ module Obstructions
 
       # loop through all values stopping before x
       while (x - pos_x).abs > 0
-        # return true if we find an obstruction
         obstruction_array << [pos_x, pos_y]
         pos_x += horizontal_increment
       end
@@ -66,12 +70,11 @@ module Obstructions
 
       # loop through all values stopping before x
       while (y - pos_y).abs > 0
-        # return true if we find an obstruction
         obstruction_array << [pos_x, pos_y]
         pos_y += vertical_increment
       end
     end
-    # default to false
+    # return array
     obstruction_array
   end
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -108,14 +108,6 @@ class King < Piece
     end
   end
 
-  def x_scope
-    1
-  end
-
-  def y_scope
-    1
-  end
-
   private
 
   def proper_length?(x, y)

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -15,12 +15,4 @@ class Knight < Piece
   def proper_length?(x, y)
     (x_position - x).abs + (y_position - y).abs == 3
   end
-
-  def x_scope
-    3
-  end
-
-  def y_scope
-    3
-  end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -76,12 +76,4 @@ class Pawn < Piece
     y_diff = (y - y_position).abs
     first_move?(y) ? (y_diff == 1 || y_diff == 2) : y_diff == 1
   end
-
-  def x_scope
-    1
-  end
-
-  def y_scope
-    2
-  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -10,6 +10,7 @@ class Piece < ActiveRecord::Base
   belongs_to :player
   belongs_to :game
 
+  # include obstructions concern for obstruction related methods
   include Obstructions
 
   # use transactions to attempt a move, fail and rollback if move
@@ -25,29 +26,37 @@ class Piece < ActiveRecord::Base
     end
   end
 
+  # method to determine if an opposing piece can block check
+  # this method is called to determine checkmate.
   def can_be_blocked?(king)
+    # get all possible squares that could be used to obstruct check
     obstruction_array = obstructed_squares(king.x_position, king.y_position)
 
-    blockers = game.pieces_remaining(!color)
-    blockers.each do |blocker|
+    opponents = game.pieces_remaining(!color)
+    # for each opponent, iterate through all squares that could obstruct
+    opponents.each do |opponent|
       obstruction_array.each do |square|
-        # return true if we find an obstruction
-        return true if blocker.valid_move?(square[0], square[1])
+        # return true if we find even one way to obstruct check
+        return true if opponent.valid_move?(square[0], square[1])
       end
     end
     false
   end
 
+  # method to determine if a piece can be captured.
+  # called to determine checkmate
   def can_be_captured?
-    opponents = game.pieces.where("color = ? and state != 'captured'", !color).to_a
-    opponents.each do |opposing_piece|
-      if opposing_piece.valid_move?(x_position, y_position)
+    opponents = game.pieces_remaining(!color)
+    opponents.each do |opponent|
+      # for each opponent, see if the checking piece can be captured
+      if opponent.valid_move?(x_position, y_position)
         return true
       end
     end
     false
   end
 
+  # determine a move is a capture move
   def capture_move?(x, y)
     captured_piece = game.obstruction(x, y)
     captured_piece && captured_piece.color != color
@@ -57,10 +66,12 @@ class Piece < ActiveRecord::Base
     color ? 'white' : 'black'
   end
 
+  # determines whether move follows the legal move pattern for a given piece type
   def legal_move?(_x, _y)
     fail NotImplementedError 'Pieces must implement #legal_move?'
   end
 
+  # determine if player_id of piece matches current turn
   def moving_own_piece?
     player_id == game.turn
   end
@@ -70,6 +81,8 @@ class Piece < ActiveRecord::Base
       (y <= MAX_BOARD_SIZE && y >= MIN_BOARD_SIZE)
   end
 
+  # this method carries out the movement of a piece and determines if there is also a
+  # capture involved. Both king and pawn override this method to carry out special moves
   def move_to(piece, params)
     x = params[:x_position].to_i
     y = params[:y_position].to_i
@@ -91,6 +104,8 @@ class Piece < ActiveRecord::Base
     x_position == x && y_position == y
   end
 
+  # this method collects an array of squares where an obstruction could occur
+  # the checks each of those squares for any obstructing piece
   def obstructed_move?(x, y)
     obstruction_array = obstructed_squares(x, y)
 
@@ -109,10 +124,13 @@ class Piece < ActiveRecord::Base
     update_attributes(x_position: x, y_position: y, state: state)
   end
 
+  # determine squares between current position and _x, _y. Method overridden
+  # by each piece.
   def obstructed_squares(_x, _y)
     fail NotImplementedError 'Pieces must implement #obstructed_squares'
   end
 
+  # determine if a move is valid
   def valid_move?(x, y)
     return false if nil_move?(x, y)
     return false unless move_on_board?(x, y)

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -7,12 +7,4 @@ class Queen < Piece
   def obstructed_squares(x, y)
     diagonal_obstruction_array(x, y).concat rectilinear_obstruction_array(x, y)
   end
-
-  def x_scope
-    7
-  end
-
-  def y_scope
-    7
-  end
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -6,12 +6,4 @@ class Rook < Piece
   def obstructed_squares(x, y)
     rectilinear_obstruction_array(x, y)
   end
-
-  def x_scope
-    7
-  end
-
-  def y_scope
-    7
-  end
 end

--- a/test/models/bishop_test.rb
+++ b/test/models/bishop_test.rb
@@ -3,64 +3,66 @@ require 'test_helper'
 # Tests specific to Bishop logic
 class BishopTest < ActiveSupport::TestCase
   test 'should be legal'  do
-    game = FactoryGirl.create(:game)
-    bishop = FactoryGirl.create(
-      :bishop,
-      color: false,
-      x_position: 3,
-      y_position: 4,
-      game_id: game.id)
+    setup_game
 
-    assert bishop.legal_move?(6, 7)
-    assert bishop.legal_move?(1, 2)
-    assert bishop.legal_move?(1, 6)
-    assert bishop.legal_move?(5, 6)
+    assert @bishop.legal_move?(6, 7)
+    assert @bishop.legal_move?(1, 2)
+    assert @bishop.legal_move?(1, 6)
+    assert @bishop.legal_move?(5, 6)
   end
 
   test 'should be illegal' do
-    game = FactoryGirl.create(:game)
-    bishop = FactoryGirl.create(
-      :bishop,
-      color: false,
-      x_position: 3,
-      y_position: 4,
-      game_id: game.id)
+    setup_game
 
-    assert_not bishop.legal_move?(5, 7)
-    assert_not bishop.legal_move?(3, 7)
-    assert_not bishop.legal_move?(1, 4)
+    assert_not @bishop.legal_move?(5, 7)
+    assert_not @bishop.legal_move?(3, 7)
+    assert_not @bishop.legal_move?(1, 4)
   end
 
   test 'should not be obstructed' do
-    game = FactoryGirl.create(:game)
-    bishop = FactoryGirl.create(
-      :bishop,
-      color: false,
-      x_position: 3,
-      y_position: 4,
-      game_id: game.id)
+    setup_game
 
-    assert_not bishop.obstructed_move?(4, 5), 'quad 1'
-    assert_not bishop.obstructed_move?(4, 3), 'quad 2'
-    assert_not bishop.obstructed_move?(2, 3), 'quad 3'
-    assert_not bishop.obstructed_move?(2, 5), 'quad 4'
+    assert_not @bishop.obstructed_move?(4, 5), 'quad 1'
+    assert_not @bishop.obstructed_move?(4, 3), 'quad 2'
+    assert_not @bishop.obstructed_move?(2, 3), 'quad 3'
+    assert_not @bishop.obstructed_move?(2, 5), 'quad 4'
   end
 
   test 'should be obstructed' do
-    game = FactoryGirl.create(:game)
-    bishop = FactoryGirl.create(
-      :bishop,
-      color: false,
-      x_position: 3,
-      y_position: 4,
-      game_id: game.id)
+    setup_game
     FactoryGirl.create(
       :pawn,
       color: false,
       x_position: 4,
       y_position: 5,
-      game_id: game.id)
+      game_id: @game.id)
 
-    assert bishop.obstructed_move?(5, 6)
+    assert @bishop.obstructed_move?(5, 6)
+  end
+
+  test 'Should return array of obstructed squares' do
+    setup_game
+
+    expected = [[4, 5], [5, 6]]
+    assert_equal expected, @bishop.obstructed_squares(6, 7)
+
+    expected = [[2, 3], [1, 2]]
+    assert_equal expected, @bishop.obstructed_squares(0, 1)
+
+    expected = [[2, 5], [1, 6]]
+    assert_equal expected, @bishop.obstructed_squares(0, 7)
+
+    expected = [[4, 3], [5, 2]]
+    assert_equal expected, @bishop.obstructed_squares(6, 1)
+  end
+
+  def setup_game
+    @game = FactoryGirl.create(:game)
+    @bishop = FactoryGirl.create(
+      :bishop,
+      color: false,
+      x_position: 3,
+      y_position: 4,
+      game_id: @game.id)
   end
 end

--- a/test/models/game_checking_test.rb
+++ b/test/models/game_checking_test.rb
@@ -18,33 +18,20 @@ class GameCheckingTest < ActiveSupport::TestCase
     assert @game.checkmate?(true)
   end
 
-  test 'knight cannot be blocked to get out of check' do
-    @game = FactoryGirl.create(
-      :game,
-      black_player_id: 1,
-      white_player_id: 2,
-      turn: 1)
-    @game.assign_pieces
+  test 'knight can not be blocked to get out of check' do
+    setup_game_and_king
 
-    @white_king = @game.pieces.find_by(type: 'King', color: true)
     black_knight = @game.pieces.find_by(type: 'Knight', color: false, x_position: 1)
     black_knight.update_attributes(x_position: 5, y_position: 2)
     black_knight.reload
 
-    assert @game.check? true
     assert_not black_knight.can_be_blocked?(@white_king)
     assert_not @game.checkmate?(true) # not in checkmate because white_pawns can capture knight
   end
 
-  test 'pawn cannot be blocked to get out of check' do
-    @game = FactoryGirl.create(
-      :game,
-      black_player_id: 1,
-      white_player_id: 2,
-      turn: 1)
-    @game.assign_pieces
+  test 'pawn can not be blocked to get out of check' do
+    setup_game_and_king
 
-    @white_king = @game.pieces.find_by(type: 'King', color: true)
     white_pawn = @game.pieces.find_by(type: 'Pawn', color: true, x_position: 3)
     white_pawn.update_attributes(y_position: 4)
     white_pawn.reload
@@ -52,7 +39,6 @@ class GameCheckingTest < ActiveSupport::TestCase
     black_pawn.update_attributes(y_position: 1)
     black_pawn.reload
 
-    assert @game.check? true
     assert_not black_pawn.can_be_blocked?(@white_king)
     assert_not @game.checkmate?(true) # not in checkmate because white_queen can capture pawn
   end
@@ -116,7 +102,7 @@ class GameCheckingTest < ActiveSupport::TestCase
     assert_not @game.checkmate?(true)
   end
 
-  def setup_check
+  def setup_game_and_king
     @game = FactoryGirl.create(
       :game,
       black_player_id: 1,
@@ -125,6 +111,10 @@ class GameCheckingTest < ActiveSupport::TestCase
     @game.assign_pieces
 
     @white_king = @game.pieces.find_by(type: 'King', color: true)
+  end
+
+  def setup_check
+    setup_game_and_king
     @pawn1 = @game.pieces.find_by(type: 'Pawn', color: true, x_position: 5)
     @pawn1.update_attributes(y_position: 2, state: 'moved')
     @pawn1.reload

--- a/test/models/rook_test.rb
+++ b/test/models/rook_test.rb
@@ -30,15 +30,30 @@ class RookTest < ActiveSupport::TestCase
     assert @rook3.obstructed_move?(4, 7), 'Rook is blocked to left'
   end
 
+  test 'Should return array of obstructed squares' do
+    setup_obstruction_tests
+
+    expected = [[4, 5], [4, 6]]
+    assert_equal expected, @rook.obstructed_squares(4, 7)
+
+    expected = [[4, 3], [4, 2], [4, 1]]
+    assert_equal expected, @rook.obstructed_squares(4, 0)
+
+    expected = [[1, 0], [2, 0], [3, 0]]
+    assert_equal expected, @rook2.obstructed_squares(4, 0)
+
+    expected = [[6, 7], [5, 7]]
+    assert_equal expected, @rook3.obstructed_squares(4, 7)
+  end
+
   # sets up a game and chooses a rook, then moves it to the center
   # of the board so it has unobstructed moves
   # selects 2 more rooks with obstructed x direction moves
   def setup_obstruction_tests
     game = FactoryGirl.create(:game)
-    @rook = game.pieces.where(type: 'Rook').last
-    @rook.x_position = 4
-    @rook.y_position = 4
-    @rook2 = game.pieces.where(x_position: 0, y_position: 0).last
-    @rook3 = game.pieces.where(x_position: 7, y_position: 7).last
+    @rook = game.pieces.find_by(x_position: 0, y_position: 7)
+    @rook.update_piece(4, 4, 'moved')
+    @rook2 = game.pieces.find_by(x_position: 0, y_position: 0)
+    @rook3 = game.pieces.find_by(x_position: 7, y_position: 7)
   end
 end


### PR DESCRIPTION
Refactored to separate piece specific obstruction logic from obstruction checks
1. Each piece now returns an array of square tuples [x, y] that need to be checked for an obstruction between current location and specified destination.
2. This array is now used in a simplified obstructed_move? function implemented in piece.rb (not overridden for each piece)
3. This array is used to check blocking in checkmate? method in game.rb