### PR TITLE
Checkmate

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -39,11 +39,11 @@ class Game < ActiveRecord::Base
     # make sure color is in check and get @piece_causing_check
     return false unless check?(color)
 
-    # see if king can get himself out of check
-    return false if checked_king.can_move_out_of_check?
-
     # see if another piece can capture checking piece
     return false if @piece_causing_check.can_be_captured?
+
+    # see if king can get himself out of check
+    return false if checked_king.can_move_out_of_check?
 
     # # see if another piece can block check
     return false if @piece_causing_check.can_be_blocked?(checked_king)

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -7,17 +7,17 @@ class King < Piece
 
   # determine if king can move himself out of check
   def can_move_out_of_check?
+    starting_x = x_position
+    starting_y = y_position
     success = false
     ((x_position - 1)..(x_position + 1)).each do |x|
       ((y_position - 1)..(y_position + 1)).each do |y|
-        Piece.transaction do
-          move_to(x_position: x, y_position: y) if valid_move?(x, y)
-          # if game.check?(color) comes up false,
-          # even once, assign  true
-          success = true unless game.check?(color)
-          # reset any attempted moves
-          fail ActiveRecord::Rollback
-        end
+        update_attributes(x_position: x, y_position: y) if valid_move?(x, y)
+        # if game.check?(color) comes up false,
+        # even once, assign  true
+        success = true unless game.check?(color)
+        # reset any attempted moves
+        update_attributes(x_position: starting_x, y_position: starting_y)
       end
     end
     success

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -33,6 +33,7 @@ class Piece < ActiveRecord::Base
     opponents = game.pieces_remaining(!color)
     # for each opponent, iterate through all squares that could obstruct
     opponents.each do |opponent|
+      next if opponent.type == 'King'
       obstruction_array.each do |square|
         # return true if we find even one way to obstruct check
         return true if opponent.valid_move?(square[0], square[1])


### PR DESCRIPTION
removed transactions from king.can_move_out_of_check?  manually move the king to and from the correct spot.

required calling piece_causing_check.can_be_captured? first.

prevented king from obstructing his own check.