### PR TITLE
Dashboard

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -25,6 +25,12 @@ class GamesController < ApplicationController
     if game.valid? && unique_players?
       game.update_attributes game_params
       game.assign_pieces
+
+      # temporary fix to remedy games that allowed a white player move
+      # before black player was assigned and gave black player a nil value
+      if game.turn.nil? && game.black_player_id.present?
+        game.update_attributes(turn: black_player_id)
+      end
       return redirect_to game_path game
     end
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -29,8 +29,9 @@ class GamesController < ApplicationController
       # temporary fix to remedy games that allowed a white player move
       # before black player was assigned and gave black player a nil value
       if game.turn.nil? && game.black_player_id.present?
-        game.update_attributes(turn: black_player_id)
+        game.update_attributes(turn: game.black_player_id)
       end
+
       return redirect_to game_path game
     end
 

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -35,10 +35,8 @@ module GamesHelper
   end
 
   def show_player
-    if current_player.id == game.white_player_id
-      "White Player: #{player_email_from_id(current_player)}"
-    else
-      "Black Player: #{player_email_from_id(current_player)}"
-    end
+    return "White Player: #{player_email_from_id(current_player)}" if current_player.id == game.white_player_id
+    return "Black Player: #{player_email_from_id(current_player)}" if current_player.id == game.black_player_id
+    nil
   end
 end

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -18,7 +18,7 @@
   <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
 <% end -%>
 
-<%- if devise_mapping.omniauthable? %>
+<%- if false %> <!-- devise_mapping.omniauthable? %> REMOVE ONCE OMNIAUTH WORKING -->
   <%- resource_class.omniauth_providers.each do |provider| %>
     <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
   <% end -%>

--- a/app/views/shared/_gameboard.html.erb
+++ b/app/views/shared/_gameboard.html.erb
@@ -11,6 +11,15 @@
 			</tr>
 	 	<% end %>
 	</table> 	
-	<p><%= raw show_player %></p>
+	<p>
+		<% unless show_player.nil? %>
+			<%= raw show_player %>
+		<% else %>
+			<%= simple_form_for game, :method => :put do |f| %>
+			  <%= f.input :black_player_id, :as => :hidden, :input_html => { :value => current_player.id } %>
+			  <%= f.submit 'Join Game' %>
+			<% end %>
+		<% end %>
+	</p>
 <% end %>
 

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -5,13 +5,15 @@ class GamesControllerTest < ActionController::TestCase
     player = FactoryGirl.create(:player)
     sign_in player
     game = FactoryGirl.create(:game, white_player_id: player.id)
-    patch :update, id: game.id, game: { black_player_id: 37 }
+    player2 = FactoryGirl.create(:player)
+    game.update_attributes(turn: nil)
+    patch :update, id: game.id, game: { black_player_id: player2.id }
     game.reload
     assert_response :found
-    assert_redirected_to game_path(assigns(:game))
-    # method exists to randomize which player is white and which is black
-    # for this reason either color may end up being player 37
-    assert game.white_player_id == 37 ||  game.black_player_id == 37
+    assert_redirected_to game_path(game)
+    assert game.black_player_id == player2.id
+    # test that a turn: nil will be assigned to black player when black_player joins game
+    assert game.turn == player2.id
   end
 
   test 'game join fail due to identical player_id\'s' do


### PR DESCRIPTION
Ensure that black player joining a game assigns black player to turn if it's nil.
By default turn = white_player_id, but if white player took a turn before #145 turn was assigned to nil leaving the game stuck.  This fix remedies any existing game in that situation.

Modify game board for an open game to show JOIN link at the bottom rather than defaulting current player to be listed as black_player.